### PR TITLE
修复链接块显示问题

### DIFF
--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -153,8 +153,12 @@
       border-radius: 8px;
       font-size: 0.9rem;
       transition: opacity 0.3s ease;
-      display: flex;
+      display: none;
       align-items: center;
+    }
+    
+    #sshlink.active {
+      display: flex;
     }
 
     .link-text {


### PR DESCRIPTION
> 补全丢失的样式

没生成链接时，不显示